### PR TITLE
Fix ARM casting issues on Xcode 12

### DIFF
--- a/Source/INTUGroupedArray/INTUGroupedArray.m
+++ b/Source/INTUGroupedArray/INTUGroupedArray.m
@@ -1124,8 +1124,8 @@
         return;
     }
     
-    BOOL concurrent = (options & NSEnumerationConcurrent);
-    BOOL reverse = (options & NSEnumerationReverse);
+    BOOL concurrent = (options & NSEnumerationConcurrent) == 0 ? NO : YES;
+    BOOL reverse = (options & NSEnumerationReverse) == 0 ? NO : YES;
     
     NSOperationQueue *concurrentQueue = nil;
     if (concurrent) {
@@ -1187,8 +1187,8 @@
         return;
     }
     
-    BOOL concurrent = (options & NSEnumerationConcurrent);
-    BOOL reverse = (options & NSEnumerationReverse);
+    BOOL concurrent = (options & NSEnumerationConcurrent) == 0 ? NO : YES;
+    BOOL reverse = (options & NSEnumerationReverse) == 0 ? NO : YES;
     
     NSOperationQueue *concurrentQueue = nil;
     if (concurrent) {
@@ -1255,8 +1255,8 @@
         return;
     }
     
-    BOOL concurrent = (options & NSEnumerationConcurrent);
-    BOOL reverse = (options & NSEnumerationReverse);
+    BOOL concurrent = (options & NSEnumerationConcurrent) == 0 ? NO : YES;
+    BOOL reverse = (options & NSEnumerationReverse) == 0 ? NO : YES;
     
     NSOperationQueue *concurrentQueue = nil;
     if (concurrent) {


### PR DESCRIPTION
ARM compilation in Xcode 12 is complaining about various casts (particularly Int -> BOOL). These are now errors.